### PR TITLE
:package: fix: Repair wheel also on macOS

### DIFF
--- a/ci/macos/repair-wheel.py
+++ b/ci/macos/repair-wheel.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+"""Ignore libarrow libraries in the wheel"""
+import logging
+import sys
+from fnmatch import fnmatch
+from pathlib import Path
+
+import delocate.tools
+from delocate import delocate_wheel
+from delocate.delocating import filter_system_libs
+from delocate.tools import _parse_otool_install_names as _parse_names
+
+logging.basicConfig(level=logging.INFO)
+
+EXCLUDE_PATTERN = "*libarrow*"
+
+
+# Patching otool search to exclude libraries we don't want parsed
+def parse_otool_install_names(stdout: str) -> dict[str, list[tuple[str, str, str]]]:
+    names = _parse_names(stdout)
+
+    for k, v in names.copy().items():
+        names[k] = [t for t in v if not (fnmatch(t[0], EXCLUDE_PATTERN))]
+
+    return names
+
+
+delocate.tools._parse_otool_install_names = parse_otool_install_names
+
+
+if __name__ == "__main__":
+    wheel, dest_dir, delocate_archs = sys.argv[1:]
+
+    wheel = Path(wheel)
+    dest_dir = Path(dest_dir)
+    require_archs = [s.strip() for s in delocate_archs.split(",")]
+
+    delocate_wheel(
+        in_wheel=wheel.as_posix(),
+        out_wheel=(dest_dir / wheel.name).as_posix(),
+        require_archs=require_archs,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,7 @@ test-extras = ["tests"]
 test-skip = "*-win*"
 
 [tool.cibuildwheel.macos]
-before-build = "bash ci/macos/prepare-build.sh"
 repair-wheel-command = "python ci/macos/repair-wheel.py {wheel} {dest_dir} {delocate_archs}"
-
 
 [tool.cibuildwheel.linux]
 before-build = "bash ci/linux/prepare-build.sh"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ build-verbosity = 2
 
 [tool.cibuildwheel.macos]
 before-build = "bash ci/macos/prepare-build.sh"
-repair-wheel-command = "cp {wheel} {dest_dir}"
+repair-wheel-command = "python ci/macos/repair-wheel.py {wheel} {dest_dir} {delocate_archs}"
 
 [tool.cibuildwheel.linux]
 before-build = "bash ci/linux/prepare-build.sh"


### PR DESCRIPTION
Needed to patch `delocate` :/. 

Adding `libpq` as static needs also additional code on the CMake side because we need to retrieve the `libpq.a`, while `find_package(PostgreSQL)` just finds the dynamic library it seems... 

It was more code than just embedding the dynamic library...